### PR TITLE
style: Make images smaller and centered

### DIFF
--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -56,6 +56,7 @@ $nav-indent: 10px !default; // extra padding for ToC subitems
 $code-annotation-padding: 13px !default; // padding inside code annotations
 $h1-margin-bottom: 21px !default; // padding under the largest header tags
 $tablet-width: 930px !default; // min width before reverting to tablet size
+$desktop-width: 1281px !default; // min width before reverting to high res desktop size.
 $phone-width: $tablet-width - $nav-width !default; // min width before reverting to mobile size
 
 

--- a/source/stylesheets/print.css.scss
+++ b/source/stylesheets/print.css.scss
@@ -80,6 +80,12 @@ body {
     color: #000;
   }
 
+  img {
+    max-width: 70%;
+    display: block;
+    margin: auto;
+  }
+
   h1 {
     @extend %header-font;
     font-size: 2.5em;

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -407,7 +407,9 @@ html, body {
   }
 
   img {
-    max-width: 100%;
+    max-width: 60%;
+    display: block;
+    margin: auto;
   }
 
   code {
@@ -527,8 +529,17 @@ html, body {
 ////////////////////////////////////////////////////////////////////////////////
 // These are the styles for phones and tablets
 // There are also a couple styles disperesed
+@media (max-width: $desktop-width) {
+  .content img {
+    max-width: 70%;
+  }
+}
 
 @media (max-width: $tablet-width) {
+  .content img {
+    max-width: 100%;
+  }
+
   .tocify-wrapper {
     left: -$nav-width;
 


### PR DESCRIPTION
With this commit, images (specifically the one for How Kelda Works) are limited
to 70% of the block width on big screens. This prevents them from being
overwhelmingly big, even if the source image is large.
Now that images don't take up the full horizontal space, we make sure to center
them.